### PR TITLE
Add option to disable greenlight in application authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,13 @@ bbb_greenlight_office365:
     hd:
 ```
 
+#### In Application Authentication
+By default, the ability for anyone to create a Greenlight account is enabled. To disable this, use `false`.
+For more information see: https://docs.bigbluebutton.org/greenlight/gl-config.html#in-application-greenlight
+```yaml
+bbb_greenlight_accounts: 'false'
+```
+
 #### RECAPTCHA
 To enable reCaptcha on the user sign up, define these 2 keys.
 You can obtain these keys by registering your domain using the following url: https://www.google.com/recaptcha/admin

--- a/templates/greenlight/env.j2
+++ b/templates/greenlight/env.j2
@@ -78,7 +78,7 @@ LDAP_ROLE_FIELD={{ bbb_greenlight_ldap.role_field | default('') }}
 #
 #   https://docs.bigbluebutton.org/greenlight/gl-overview.html#accounts-and-profile
 #
-ALLOW_GREENLIGHT_ACCOUNTS=true
+ALLOW_GREENLIGHT_ACCOUNTS={{ bbb_greenlight_accounts | default('true') }}
 
 # To enable reCaptcha on the user sign up, define these 2 keys
 # You can obtain these keys by registering your domain using the following url:


### PR DESCRIPTION
In order to enable an authentication provider and disable the in application authentication at the same time.

use `'false'` with quotes as it gets interpreted as a boolean resulting in true -> True and false -> False.
Greenlight seems to compare `ALLOW_GREENLIGHT_ACCOUNTS==true`.
Using false or False is always false but True is not equal true here and results in disabling it too which isnt intuitive. Hopefully prevent that by having quotes in the example.