### PR TITLE
Option to disable recordings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Ansible role for a bigbluebutton installation (following the documentation on ht
 | `bbb_greenlight_enable` | enable installation of the greenlight client | `yes` |
 | `bbb_greenlight_secret` | Secret for greenlight _(required when using greenlight)_ |  | can be generated with `openssl rand -hex 64`
 | `bbb_greenlight_db_password` | Password for greenlight's database  _(required when using greenlight)_ | | can be generated with `openssl rand -hex 16`
+| `bbb_disable_recordings` | Disable options in gui to have recordings | `no` | [Recordings are running constantly in background](https://github.com/bigbluebutton/bigbluebutton/issues/9202) which is relevant as privacy relevant user data is stored
 | `bbb_api_demos_enable` | enable installation of the api demos | `no` |
 | `bbb_nodejs_version` | version of nodejs to be installed | `8.x` |
 | `bbb_system_locale` | the system locale to use | `en_US.UTF-8` |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -5,6 +5,7 @@ bbb_coturn_enable: true
 bbb_turn_enable: true
 bbb_turn_server: "{{ bbb_hostname }}"
 bbb_greenlight_enable: true
+bbb_disable_recordings: false
 bbb_api_demos_enable: false
 bbb_nodejs_version: 8.x
 

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -88,3 +88,27 @@
      src: bbb/bigbluebutton.j2
      dest: /etc/nginx/sites-available/bigbluebutton
   notify: reload nginx
+
+- name: ensure default recording is disabled
+  lineinfile:
+    path: /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties
+    regexp: '^disableRecordingDefault'
+    line: 'disableRecordingDefault=true'
+  when: bbb_disable_recordings
+  notify: restart bigbluebutton
+
+- name: ensure recording auto start is disabled
+  lineinfile:
+    path: /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties
+    regexp: '^autoStartRecording'
+    line: 'autoStartRecording=false'
+  when: bbb_disable_recordings
+  notify: restart bigbluebutton
+
+- name: ensure users are not allowed to start recording
+  lineinfile:
+    path: /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties
+    regexp: '^allowStartStopRecording'
+    line: 'allowStartStopRecording=false'
+  when: bbb_disable_recordings
+  notify: restart bigbluebutton

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -89,12 +89,11 @@
      dest: /etc/nginx/sites-available/bigbluebutton
   notify: reload nginx
 
-- name: ensure default recording is disabled
+- name: set recording default
   lineinfile:
     path: /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties
     regexp: '^disableRecordingDefault'
-    line: 'disableRecordingDefault=true'
-  when: bbb_disable_recordings
+    line: 'disableRecordingDefault={{ bbb_disable_recordings | ternary("true", "false") }}'
   notify: restart bigbluebutton
 
 - name: ensure recording auto start is disabled
@@ -102,13 +101,11 @@
     path: /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties
     regexp: '^autoStartRecording'
     line: 'autoStartRecording=false'
-  when: bbb_disable_recordings
   notify: restart bigbluebutton
 
-- name: ensure users are not allowed to start recording
+- name: allow/disable users to start recordings
   lineinfile:
     path: /usr/share/bbb-web/WEB-INF/classes/bigbluebutton.properties
     regexp: '^allowStartStopRecording'
-    line: 'allowStartStopRecording=false'
-  when: bbb_disable_recordings
+    line: 'allowStartStopRecording={{ bbb_disable_recordings | ternary("false", "true") }}'
   notify: restart bigbluebutton


### PR DESCRIPTION
As its [quite common](https://github.com/stadtulm/a13-ansible/blob/253d669e412e171397eb37a5695b48ff8e1cac5e/roles/bbb-ulmlernt/tasks/main.yml#L2-L21) to disable the recordings on a BBB installation I think its helpful to have this in a basic role.

This also simplifies configuration when the config changes on future versions of BBB.

I thought about having a toggle (allow recordings / disable them completely) but `autoStartRecording` only has a clear state when disabled.