### PR TITLE
Improve greenlight nginx to be equal to bbb-install.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Ansible role for a bigbluebutton installation (following the documentation on ht
 | `bbb_letsencrypt_enable` | Enable letsencrypt/HTTPS | `yes` |
 | `bbb_letsencrypt_email` | E-mail for use with letsencrypt _(required when using LE)_|  |
 | `bbb_nginx_privacy` | only log errors not access | `yes` |
+| `bbb_nginx_dh` | generate Diff-Hellmann for nginx | `yes` | same place like bbb-install.sh
 | `bbb_coturn_enable` | enable installation of the TURN-server | `yes` |
 | `bbb_turn_enable` | enable the use uf TURN in general | `yes` |
 | `bbb_turn_server` | the adress for the TURN-Server to use | `{{ bbb_hostname }}` | has to be a fully qualified domain name

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Ansible role for a bigbluebutton installation (following the documentation on ht
 | `bbb_hostname` | Hostname for this BigBlueButton instance _(required)_ | {{ ansible_fqdn_hostname }} |
 | `bbb_letsencrypt_enable` | Enable letsencrypt/HTTPS | `yes` |
 | `bbb_letsencrypt_email` | E-mail for use with letsencrypt _(required when using LE)_|  |
+| `bbb_nginx_privacy` | only log errors not access | `yes` |
 | `bbb_coturn_enable` | enable installation of the TURN-server | `yes` |
 | `bbb_turn_enable` | enable the use uf TURN in general | `yes` |
 | `bbb_turn_server` | the adress for the TURN-Server to use | `{{ bbb_hostname }}` | has to be a fully qualified domain name

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,7 @@
 bbb_hostname: "{{ ansible_fqdn }}"
 bbb_letsencrypt_enable: true
 bbb_nginx_privacy: true
+bbb_nginx_dh: true
 
 bbb_coturn_enable: true
 bbb_turn_enable: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,6 +1,8 @@
 ---
 bbb_hostname: "{{ ansible_fqdn }}"
 bbb_letsencrypt_enable: true
+bbb_nginx_privacy: true
+
 bbb_coturn_enable: true
 bbb_turn_enable: true
 bbb_turn_server: "{{ bbb_hostname }}"

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -1,5 +1,7 @@
 ---
 - name: Converge
   hosts: all
+  vars:
+  - bbb_nginx_dh: false
   roles:
     - role: n0emis.bigbluebutton

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -87,13 +87,14 @@
   file:
     path: /etc/nginx/ssl
     state: directory
-
+  when: bbb_nginx_dh
 
 - name: Generate DH Parameters with a different size (4096 bits)
   openssl_dhparam:
     path: /etc/nginx/ssl/dhp-4096.pem
     size: 4096
   notify: reload nginx
+  when: bbb_nginx_dh
 
 - name: copy bbb's nginx vhost
   template:

--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -83,6 +83,18 @@
     dest: /usr/share/bbb-web/WEB-INF/classes/spring/turn-stun-servers.xml
   notify: restart bigbluebutton
 
+- name: create ssl folder for nginx
+  file:
+    path: /etc/nginx/ssl
+    state: directory
+
+
+- name: Generate DH Parameters with a different size (4096 bits)
+  openssl_dhparam:
+    path: /etc/nginx/ssl/dhp-4096.pem
+    size: 4096
+  notify: reload nginx
+
 - name: copy bbb's nginx vhost
   template:
      src: bbb/bigbluebutton.j2

--- a/tasks/greenlight.yml
+++ b/tasks/greenlight.yml
@@ -41,8 +41,11 @@
 
 - name: copy greenlight nginx configuration file
   template:
-    src: greenlight/greenlight.nginx.j2
-    dest: /etc/bigbluebutton/nginx/greenlight.nginx
+    src: "greenlight/{{ item }}.j2"
+    dest: "/etc/bigbluebutton/nginx/{{ item }}"
+  with_items:
+  - greenlight.nginx
+  - greenlight-redirect.nginx
   notify: reload nginx
 
 - name: start greenlight

--- a/templates/bbb/bigbluebutton.j2
+++ b/templates/bbb/bigbluebutton.j2
@@ -19,7 +19,12 @@ server {
     ssl_prefer_server_ciphers on;
     ssl_dhparam /etc/nginx/ssl/dhp-4096.pem;
 
+{% if bbb_nginx_privacy %}
+  error_log /var/log/nginx/bigbluebutton.error.log;
+  access_log /dev/null;
+{% else %}
   access_log  /var/log/nginx/bigbluebutton.access.log;
+{% endif %}
 
    # Handle RTMPT (RTMP Tunneling).  Forwards requests
    # to Red5 on port 5080

--- a/templates/bbb/bigbluebutton.j2
+++ b/templates/bbb/bigbluebutton.j2
@@ -17,7 +17,9 @@ server {
     ssl_protocols TLSv1.2;
     ssl_ciphers "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS:!AES256";
     ssl_prefer_server_ciphers on;
+{% if bbb_nginx_dh %}
     ssl_dhparam /etc/nginx/ssl/dhp-4096.pem;
+{% endif %}
 
 {% if bbb_nginx_privacy %}
   error_log /var/log/nginx/bigbluebutton.error.log;

--- a/templates/bbb/bigbluebutton.j2
+++ b/templates/bbb/bigbluebutton.j2
@@ -1,84 +1,78 @@
 server {
-        listen 80;
-        listen [::]:80;
-        server_name {{ bbb_hostname }};
-        return 301 https://$host$request_uri;
+    listen 80;
+    listen [::]:80;
+    server_name {{ bbb_hostname }};
+    return 301 https://$host$request_uri;
 }
 
-
 server {
-    listen 443 ssl;
-    listen [::]:443 ssl;
-    server_name {{ bbb_hostname }};
 
+  listen 443 ssl http2;
+  listen [::]:443 ssl http2;
+  server_name {{ bbb_hostname }};
     ssl_certificate {{ bbb_ssl_cert }};
     ssl_certificate_key {{ bbb_ssl_key }};
     ssl_session_cache shared:SSL:10m;
     ssl_session_timeout 10m;
-    ssl_protocols TLSv1 TLSv1.1 TLSv1.2;
+    ssl_protocols TLSv1.2;
     ssl_ciphers "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS:!AES256";
     ssl_prefer_server_ciphers on;
+    ssl_dhparam /etc/nginx/ssl/dhp-4096.pem;
 
-    access_log  /var/log/nginx/bigbluebutton.access.log;
+  access_log  /var/log/nginx/bigbluebutton.access.log;
 
-	# Handle RTMPT (RTMP Tunneling).  Forwards requests
-	# to Red5 on port 5080
-    location ~ (/open/|/close/|/idle/|/send/|/fcs/) {
-        proxy_pass         http://127.0.0.1:5080;
-        proxy_redirect     off;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+   # Handle RTMPT (RTMP Tunneling).  Forwards requests
+   # to Red5 on port 5080
+  location ~ (/open/|/close/|/idle/|/send/|/fcs/) {
+    proxy_pass         http://127.0.0.1:5080;
+    proxy_redirect     off;
+    proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
 
-        client_max_body_size       10m;
-        client_body_buffer_size    128k;
+    client_max_body_size       10m;
+    client_body_buffer_size    128k;
 
-        proxy_connect_timeout      90;
-        proxy_send_timeout         90;
-        proxy_read_timeout         90;
+    proxy_connect_timeout      90;
+    proxy_send_timeout         90;
+    proxy_read_timeout         90;
 
-        proxy_buffering            off;
-        keepalive_requests         1000000000;
-    }
+    proxy_buffering            off;
+    keepalive_requests         1000000000;
+  }
 
-	# Handle desktop sharing tunneling.  Forwards
-	# requests to Red5 on port 5080.
-    location /deskshare {
-        proxy_pass         http://127.0.0.1:5080;
-        proxy_redirect     default;
-        proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
-        client_max_body_size       10m;
-        client_body_buffer_size    128k;
-        proxy_connect_timeout      90;
-        proxy_send_timeout         90;
-        proxy_read_timeout         90;
-        proxy_buffer_size          4k;
-        proxy_buffers              4 32k;
-        proxy_busy_buffers_size    64k;
-        proxy_temp_file_write_size 64k;
-        include    fastcgi_params;
-    }
+  # Handle desktop sharing tunneling.  Forwards
+  # requests to Red5 on port 5080.
+  location /deskshare {
+     proxy_pass         http://127.0.0.1:5080;
+     proxy_redirect     default;
+     proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+     client_max_body_size       10m;
+     client_body_buffer_size    128k;
+     proxy_connect_timeout      90;
+     proxy_send_timeout         90;
+     proxy_read_timeout         90;
+     proxy_buffer_size          4k;
+     proxy_buffers              4 32k;
+     proxy_busy_buffers_size    64k;
+     proxy_temp_file_write_size 64k;
+     include    fastcgi_params;
+  }
 
-	# BigBlueButton landing page.
-    location / {
-        root   /var/www/bigbluebutton-default;
-        index  index.html index.htm;
-	    expires 1m;
-    }
+  # BigBlueButton landing page.
+  location / {
+    root   /var/www/bigbluebutton-default;
+    index  index.html index.htm;
+    expires 1m;
+  }
 
-	# Include specific rules for record and playback
-    include /etc/bigbluebutton/nginx/*.nginx;
+  # Include specific rules for record and playback
+  include /etc/bigbluebutton/nginx/*.nginx;
 
-    #error_page  404  /404.html;
+  #error_page  404  /404.html;
 
-    # Redirect server error pages to the static page /50x.html
-    #
-    error_page   500 502 503 504  /50x.html;
-    location = /50x.html {
-        root   /var/www/nginx-default;
-    }
-
-{% if bbb_greenlight_enable %}
-    location = / {
-        return 307 /b;
-    }
-{% endif %}
+  # Redirect server error pages to the static page /50x.html
+  #
+  error_page   500 502 503 504  /50x.html;
+  location = /50x.html {
+    root   /var/www/nginx-default;
+  }
 }

--- a/templates/greenlight/greenlight-redirect.nginx.j2
+++ b/templates/greenlight/greenlight-redirect.nginx.j2
@@ -1,0 +1,3 @@
+location = / {
+  return 307 /b;
+}


### PR DESCRIPTION
`location=/ ` is duplicated.
It is installed by BBB: `/etc/bigbluebutton/nginx/greenlight-redirect.nginx`

----
Copy from new `bbb-install.sh` (syntax should be holded)