### PR TITLE
Disable nginx access_log, enable error_log instead

### DIFF
--- a/templates/bbb/bigbluebutton.j2
+++ b/templates/bbb/bigbluebutton.j2
@@ -19,7 +19,8 @@ server {
     ssl_ciphers "ECDH+AESGCM:DH+AESGCM:ECDH+AES256:DH+AES256:ECDH+AES128:DH+AES:ECDH+3DES:DH+3DES:RSA+AESGCM:RSA+AES:RSA+3DES:!aNULL:!MD5:!DSS:!AES256";
     ssl_prefer_server_ciphers on;
 
-    access_log  /var/log/nginx/bigbluebutton.access.log;
+    error_log /var/log/nginx/bigbluebutton.error.log;
+    access_log /dev/null;
 
 	# Handle RTMPT (RTMP Tunneling).  Forwards requests
 	# to Red5 on port 5080


### PR DESCRIPTION
### What does this PR do?
- Disabled `access_log` for nginx by setting log target `/dev/null`
- Enabled `error_log` for nginx, so that errors and critical exceptions of nginx are still logged

### Motivation
- improve data privacy by default (this is also a suggested change from https://docs.bigbluebutton.org/admin/privacy.html )
- in case the access_log is temporarily needed (for example during a DDoS), the nginx configuration can easily be changed and applied without the need to restart nginx.