### PR TITLE
fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ansible role for a bigbluebutton installation (following the documentation on ht
 ## Role Variables
 | Variable Name | Function | Default value | Comment |
 | ------------- | -------- | ------------- | ------- |
-| `bbb_hostname` | Hostname for this BigBlueButton instance _(required)_ | `{{ ansible_fqdn_hostname }}` |
+| `bbb_hostname` | Hostname for this BigBlueButton instance _(required)_ | `{{ ansible_fqdn }}` |
 | `bbb_state` | Install BigBlueButton to state | `present` | for updating BigBlueButton with this role use `latest`
 | `bbb_letsencrypt_enable` | Enable letsencrypt/HTTPS | `yes` |
 | `bbb_letsencrypt_email` | E-mail for use with letsencrypt _(required when using LE)_|  |


### PR DESCRIPTION
Hello,

I noticed a typo in the README, so here is my first contribution here :slightly_smiling_face: 

The default value for `bbb_hostname` was documented as `ansible_fqdn_hostname` instead of `ansible_fqdn`.