### PR TITLE
fix lint warning: [201] Trailing whitespace

### DIFF
--- a/tasks/locale.yml
+++ b/tasks/locale.yml
@@ -28,7 +28,7 @@
       changed_when: false
       check_mode: no
       register: localea
-      
+
     - name: Configure locale to '{{ bbb_system_locale }}'
       command: >
         localedef -c -i {{ bbb_system_locale1 }} -f {{ bbb_system_locale2 }} {{ bbb_system_locale }}


### PR DESCRIPTION
fix the following linting warning by removing a trailing whitespace
```
[201] Trailing whitespace
tasks/locale.yml:31
```