### PR TITLE
add bbb_mongodb_version to defaults 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,6 +37,7 @@ bbb_cpuschedule: true
 bbb_freeswitch_ipv6: true
 bbb_freeswitch_external_ip: "stun:{{ (bbb_stun_servers | first).server }}"
 bbb_system_locale: en_US.UTF-8
+bbb_mongodb_version: 3.4
 
 bbb_ssl_cert: "/etc/letsencrypt/live/{{ bbb_hostname }}/fullchain.pem"
 bbb_ssl_key: "/etc/letsencrypt/live/{{ bbb_hostname }}/privkey.pem"

--- a/tasks/repositories.yml
+++ b/tasks/repositories.yml
@@ -34,5 +34,5 @@
     repo: "{{ item }}"
     state: present
   with_items:
-    - "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu/ {{ ansible_distribution_release | lower }}/mongodb-org/{{ mongodb_version | default('3.4') }} multiverse"
+    - "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu/ {{ ansible_distribution_release | lower }}/mongodb-org/{{ bbb_mongodb_version }} multiverse"
     - "deb {{ bbb_apt_mirror }}/xenial-22/ bigbluebutton-xenial main"


### PR DESCRIPTION
add lintignore for this linting warning
```
[204] Lines should be no longer than 160 chars
tasks/main.yml:59
    - "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu {{ ansible_distribution_release | lower }}/mongodb-org/{{ mongodb_version | default('3.4') }} multiverse"
```