### PR TITLE
configure email account verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Ansible role for a bigbluebutton installation (following the documentation on ht
 | `bbb_greenlight_secret` | Secret for greenlight _(required when using greenlight)_ |  | can be generated with `openssl rand -hex 64`
 | `bbb_greenlight_db_password` | Password for greenlight's database  _(required when using greenlight)_ | | can be generated with `openssl rand -hex 16`
 | `bbb_greenlight_default_registration` | Registration option open(default), invite or approval
-| `bbb_allow_mail_notifications`  | Require E-Mail verification for greenlight account creation | `true` |
+| `bbb_allow_mail_notifications`  | Set this to true if you want GreenLight to send verification emails upon the creation of a new account | `true` |
 | `bbb_disable_recordings` | Disable options in gui to have recordings | `no` | [Recordings are running constantly in background](https://github.com/bigbluebutton/bigbluebutton/issues/9202) which is relevant as privacy relevant user data is stored
 | `bbb_api_demos_enable` | enable installation of the api demos | `no` |
 | `bbb_mute_on_start:` | start with muted mic on join | `no` |

--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ Ansible role for a bigbluebutton installation (following the documentation on ht
 | `bbb_nginx_dh` | generate Diff-Hellmann for nginx | `yes` | same place like bbb-install.sh
 | `bbb_coturn_enable` | enable installation of the TURN-server | `yes` |
 | `bbb_coturn_server` | server name on coturn (realm) | `{{ bbb_hostname }}` |
-| `bbb_coturn_port` | the port for the TURN-Server to use | `3443` | 
-| `bbb_coturn_port_tls` | the port for tls for the TURN-Server to use | `3443` | 
+| `bbb_coturn_port` | the port for the TURN-Server to use | `3443` |
+| `bbb_coturn_port_tls` | the port for tls for the TURN-Server to use | `3443` |
 | `bbb_coturn_secret` | Secret for the TURN-Server  _(required)_ | | can be generated with `openssl rand -hex 16`
 | `bbb_turn_enable` | enable the use uf TURN in general | `yes` |
 | `bbb_stun_servers` | a list of STUN-Server to use | `{{ bbb_hostname }}` | an array with key `server` - take a look in defaults/main.yml
@@ -24,6 +24,7 @@ Ansible role for a bigbluebutton installation (following the documentation on ht
 | `bbb_greenlight_secret` | Secret for greenlight _(required when using greenlight)_ |  | can be generated with `openssl rand -hex 64`
 | `bbb_greenlight_db_password` | Password for greenlight's database  _(required when using greenlight)_ | | can be generated with `openssl rand -hex 16`
 | `bbb_greenlight_default_registration` | Registration option open(default), invite or approval
+| `bbb_allow_mail_notifications`  | Require E-Mail verification for greenlight account creation | `true` |
 | `bbb_disable_recordings` | Disable options in gui to have recordings | `no` | [Recordings are running constantly in background](https://github.com/bigbluebutton/bigbluebutton/issues/9202) which is relevant as privacy relevant user data is stored
 | `bbb_api_demos_enable` | enable installation of the api demos | `no` |
 | `bbb_mute_on_start:` | start with muted mic on join | `no` |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,7 @@ bbb_turn_servers:
   tls: true
 
 bbb_greenlight_enable: true
+bbb_allow_mail_notifications: true
 bbb_greenlight_hosts: "{{ bbb_hostname }}"
 bbb_disable_recordings: false
 bbb_api_demos_enable: false

--- a/templates/greenlight/env.j2
+++ b/templates/greenlight/env.j2
@@ -104,7 +104,7 @@ GOOGLE_ANALYTICS_TRACKING_ID=
 # Set this to true if you want GreenLight to send verification emails upon
 # the creation of a new account
 #
-ALLOW_MAIL_NOTIFICATIONS=true
+ALLOW_MAIL_NOTIFICATIONS={{ bbb_allow_mail_notifications }}
 #
 # The notifications are sent using sendmail, unless the SMTP_SERVER variable is set.
 # In that case, make sure the rest of the variables are properly set.


### PR DESCRIPTION
create option to disable e-mail account verification via e-mail.

if you set ``bbb_require_email_verification`` to ``false``, you are able to create accounts without receiving any mail.

Workaround for https://github.com/n0emis/ansible-role-bigbluebutton/issues/38