### PR TITLE
fix CPUSchedulingPolicy in FreeSWITCH service

### DIFF
--- a/tasks/config.yml
+++ b/tasks/config.yml
@@ -162,8 +162,8 @@
 - name: enable CPUSchedulingPolicy in FreeSWITCH service
   lineinfile:
     path: /lib/systemd/system/freeswitch.service
-    regexp: '^CPUSchedulingPolicy=rr'
-    line: '#CPUSchedulingPolicy=rr'
+    regexp: '^#?CPUSchedulingPolicy=rr'
+    line: 'CPUSchedulingPolicy=rr'
   notify:
   - restart freeswitch
   - reload systemd
@@ -172,7 +172,7 @@
 - name: disable CPUSchedulingPolicy in FreeSWITCH service
   lineinfile:
     path: /lib/systemd/system/freeswitch.service
-    regexp: '^CPUSchedulingPolicy=rr'
+    regexp: '^#?CPUSchedulingPolicy=rr'
     line: '#CPUSchedulingPolicy=rr'
   notify:
   - freeswitch


### PR DESCRIPTION
I found 2 issues in FreeSWITCH service definition :

- When `bbb_cpuschedule` is set to `true`, the `CPUSchedulingPolicy=rr` line
is still commented in `/lib/systemd/system/freeswitch.service`.

- Duplicate lines are added to the end of `/lib/systemd/system/freeswitch.service` when the role is applied multiple time with the same `bbb_cpuschedule` value.