### PR TITLE
 Add bbb monitoring all in one 

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Ansible role for a bigbluebutton installation (following the documentation on ht
 | `bbb_dialplan_energy_level` | Set energy level of dailplan for FreeSWITCH | `100` | only for selected profile `bbb_dialplan_quality`
 | `bbb_dialplan_comfort_noise` | Set comfort noise of dailplan for FreeSWITCH | `1400` | only for selected profile `bbb_dialplan_quality`
 | `bbb_webhooks_enable` | install bbb-webhooks | `no` |
-| `bbb_monitoring_enable` | deploy [all in one monitoring stack](https://bigbluebutton-exporter.greenstatic.dev/installation/all_in_one_monitoring_stack/) (docker) | `no` |
-| `bbb_monitoring_directory` | Directory for the docker compose files | `/root/bbb-monitoring` |
-| `bbb_monitoring_port` | Internal Port for the monitoring werbservice | `3001` |
+| `bbb_monitoring_all_in_one_enable` | deploy [all in one monitoring stack](https://bigbluebutton-exporter.greenstatic.dev/installation/all_in_one_monitoring_stack/) (docker) | `no` |
+| `bbb_monitoring_all_in_one_directory` | Directory for the docker compose files | `/root/bbb-monitoring` |
+| `bbb_monitoring_all_in_one_port` | Internal Port for the monitoring werbservice | `3001` |
 | `bbb_monitoring_recordings_from_disk` | Collect recordings metrics by querying the disk instead of the API. See [this](https://bigbluebutton-exporter.greenstatic.dev/exporter-user-guide/#optimizations) for details. | `true`
 
 ### Extra options for Greenlight

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Ansible role for a bigbluebutton installation (following the documentation on ht
 | `bbb_dialplan_energy_level` | Set energy level of dailplan for FreeSWITCH | `100` | only for selected profile `bbb_dialplan_quality`
 | `bbb_dialplan_comfort_noise` | Set comfort noise of dailplan for FreeSWITCH | `1400` | only for selected profile `bbb_dialplan_quality`
 | `bbb_webhooks_enable` | install bbb-webhooks | `no` |
+| `bbb_monitoring_enable` | deploy [all in one monitoring stack](https://bigbluebutton-exporter.greenstatic.dev/installation/all_in_one_monitoring_stack/) (docker) | `no` |
+| `bbb_monitoring_directory` | Directory for the docker compose files | `/root/bbb-monitoring` |
+| `bbb_monitoring_port` | Internal Port for the monitoring werbservice | `3001` |
+| `bbb_monitoring_recordings_from_disk` | Collect recordings metrics by querying the disk instead of the API. See [this](https://bigbluebutton-exporter.greenstatic.dev/exporter-user-guide/#optimizations) for details. | `true`
 
 ### Extra options for Greenlight
 The Web-Frontend has some extra configuration options, listed below:

--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Ansible role for a bigbluebutton installation (following the documentation on ht
 | `bbb_dialplan_comfort_noise` | Set comfort noise of dailplan for FreeSWITCH | `1400` | only for selected profile `bbb_dialplan_quality`
 | `bbb_webhooks_enable` | install bbb-webhooks | `no` |
 | `bbb_monitoring_all_in_one_enable` | deploy [all in one monitoring stack](https://bigbluebutton-exporter.greenstatic.dev/installation/all_in_one_monitoring_stack/) (docker) | `no` |
+| `bbb_monitoring_all_in_one_version` | Version of the `greenstatic/bigbluebutton-exporter` docker image | `latest` |
 | `bbb_monitoring_all_in_one_directory` | Directory for the docker compose files | `/root/bbb-monitoring` |
 | `bbb_monitoring_all_in_one_port` | Internal Port for the monitoring werbservice | `3001` |
 | `bbb_monitoring_recordings_from_disk` | Collect recordings metrics by querying the disk instead of the API. See [this](https://bigbluebutton-exporter.greenstatic.dev/exporter-user-guide/#optimizations) for details. | `true`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -51,3 +51,8 @@ bbb_apt_mirror: "https://ubuntu.bigbluebutton.org"
 bbb_apt_key: 770C4267C5E63474D171B60937B5DD5EFAB46452
 
 ansible_python_interpreter: "/usr/bin/python3"
+
+bbb_monitoring_enable: false
+bbb_monitoring_version: "v0.5.2"
+bbb_monitoring_directory: "/root/bbb-monitoring"
+bbb_monitoring_port: 3001

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,7 @@ bbb_apt_key: 770C4267C5E63474D171B60937B5DD5EFAB46452
 ansible_python_interpreter: "/usr/bin/python3"
 
 bbb_monitoring_all_in_one_enable: false
+bbb_monitoring_all_in_one_version: latest
 bbb_monitoring_all_in_one_directory: "/root/bbb-monitoring"
 bbb_monitoring_all_in_one_port: 3001
 bbb_monitoring_recordings_from_disk: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,7 +52,7 @@ bbb_apt_key: 770C4267C5E63474D171B60937B5DD5EFAB46452
 
 ansible_python_interpreter: "/usr/bin/python3"
 
-bbb_monitoring_enable: false
-bbb_monitoring_directory: "/root/bbb-monitoring"
-bbb_monitoring_port: 3001
+bbb_monitoring_all_in_one_enable: false
+bbb_monitoring_all_in_one_directory: "/root/bbb-monitoring"
+bbb_monitoring_all_in_one_port: 3001
 bbb_monitoring_recordings_from_disk: true

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -53,6 +53,6 @@ bbb_apt_key: 770C4267C5E63474D171B60937B5DD5EFAB46452
 ansible_python_interpreter: "/usr/bin/python3"
 
 bbb_monitoring_enable: false
-bbb_monitoring_version: "v0.5.2"
 bbb_monitoring_directory: "/root/bbb-monitoring"
 bbb_monitoring_port: 3001
+bbb_monitoring_recordings_from_disk: true

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -27,3 +27,9 @@
 - name: reload systemd
   systemd:
     daemon_reload: true
+
+- name: restart monitoring
+  docker_compose:
+    pull: no
+    restarted: true
+    project_src: "{{ bbb_monitoring_directory }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -32,4 +32,4 @@
   docker_compose:
     pull: no
     restarted: true
-    project_src: "{{ bbb_monitoring_directory }}"
+    project_src: "{{ bbb_monitoring_all_in_one_directory }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -75,3 +75,6 @@
 
 - import_tasks: greenlight.yml
   when: bbb_greenlight_enable
+
+- import_tasks: monitoring.yml
+  when: bbb_monitoring_enable

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -76,5 +76,5 @@
 - import_tasks: greenlight.yml
   when: bbb_greenlight_enable
 
-- import_tasks: monitoring.yml
-  when: bbb_monitoring_enable
+- import_tasks: monitoring/all_in_one.yml
+  when: bbb_monitoring_all_in_one_enable

--- a/tasks/monitoring.yml
+++ b/tasks/monitoring.yml
@@ -1,0 +1,46 @@
+---
+- name: create monitoring directory
+  file:
+    path: "{{ bbb_monitoring_directory }}"
+    state: directory
+
+- name: register bbb secret
+  command: bbb-conf --secret
+  changed_when: false
+  register: result
+  when: not bbb_secret is defined or not bbb_baseurl is defined
+
+- name: parse bbb secret
+  set_fact:
+    bbb_secret: "{{ result.stdout | regex_search('Secret: ([a-zA-Z0-9]*)', multiline=True) |  regex_replace('Secret: ') }}"
+    cacheable: true
+  when: not bbb_baseurl is defined
+
+- name: parse bbb baseurl
+  set_fact:
+    bbb_baseurl: "{{ result.stdout | regex_search('URL:\\s*(https?:\\/\\/.*)', multiline=True) |  regex_replace('URL: ') }}"
+    cacheable: true
+  when: not bbb_baseurl is defined
+
+- name: copy docker files into place
+  template:
+    src: "monitoring/{{ item }}.j2"
+    dest: "{{ bbb_monitoring_directory }}/{{ item }}"
+  with_items:
+    - bbb_exporter_secrets.env
+    - docker-compose.yaml
+    - prometheus.yaml
+  notify: restart monitoring
+
+- name: copy monitoring nginx configuration file
+  template:
+    src: "monitoring/monitoring.nginx.j2"
+    dest: "/etc/bigbluebutton/nginx/monitoring.nginx"
+  notify: reload nginx
+
+- name: start monitoring
+  docker_compose:
+    pull: true
+    project_src: /root/bbb-monitoring/
+  when: bbb_monitoring_enable
+

--- a/tasks/monitoring/all_in_one.yml
+++ b/tasks/monitoring/all_in_one.yml
@@ -1,7 +1,7 @@
 ---
 - name: create monitoring directory
   file:
-    path: "{{ bbb_monitoring_directory }}"
+    path: "{{ bbb_monitoring_all_in_one_directory }}"
     state: directory
 
 - name: register bbb secret
@@ -25,7 +25,7 @@
 - name: copy docker files into place
   template:
     src: "monitoring/{{ item }}.j2"
-    dest: "{{ bbb_monitoring_directory }}/{{ item }}"
+    dest: "{{ bbb_monitoring_all_in_one_directory }}/{{ item }}"
   with_items:
     - bbb_exporter_secrets.env
     - docker-compose.yaml
@@ -42,5 +42,5 @@
   docker_compose:
     pull: true
     project_src: /root/bbb-monitoring/
-  when: bbb_monitoring_enable
+  when: bbb_monitoring_all_in_one_enable
 

--- a/templates/monitoring/bbb_exporter_secrets.env.j2
+++ b/templates/monitoring/bbb_exporter_secrets.env.j2
@@ -1,0 +1,2 @@
+API_BASE_URL={{ bbb_baseurl }}api/
+API_SECRET={{ bbb_secret }}

--- a/templates/monitoring/docker-compose.yaml.j2
+++ b/templates/monitoring/docker-compose.yaml.j2
@@ -10,7 +10,7 @@ services:
       - "/var/bigbluebutton:/var/bigbluebutton:ro"
     environment:
       BIND_IP: "127.0.0.1"
-      RECORDINGS_METRICS_READ_FROM_DISK: "true"
+      RECORDINGS_METRICS_READ_FROM_DISK: "{{ 'true' if bbb_monitoring_recordings_from_disk else 'false' }}"
     env_file:
       - bbb_exporter_secrets.env
     restart: unless-stopped

--- a/templates/monitoring/docker-compose.yaml.j2
+++ b/templates/monitoring/docker-compose.yaml.j2
@@ -39,7 +39,7 @@ services:
     network_mode: host
     environment:
       GF_SERVER_HTTP_ADDR: "127.0.0.1"
-      GF_SERVER_HTTP_PORT: "{{ bbb_monitoring_port }}"
+      GF_SERVER_HTTP_PORT: "{{ bbb_monitoring_all_in_one_port }}"
       GF_SERVER_ROOT_URL: "https://{{ bbb_hostname }}/monitoring"
     volumes:
       - "grafana_data:/var/lib/grafana"

--- a/templates/monitoring/docker-compose.yaml.j2
+++ b/templates/monitoring/docker-compose.yaml.j2
@@ -1,0 +1,65 @@
+version: '3.2'
+services:
+  bbb-exporter:
+    container_name: bbb-exporter
+    image: greenstatic/bigbluebutton-exporter:v0.5.2
+    network_mode: host
+    volumes:
+      # Can be removed if `RECORDINGS_METRICS_READ_FROM_DISK` is set to false (or omitted).
+      # See https://bigbluebutton-exporter.greenstatic.dev/exporter-user-guide/#optimizations for details.
+      - "/var/bigbluebutton:/var/bigbluebutton:ro"
+    environment:
+      BIND_IP: "127.0.0.1"
+      RECORDINGS_METRICS_READ_FROM_DISK: "true"
+    env_file:
+      - bbb_exporter_secrets.env
+    restart: unless-stopped
+
+  prometheus:
+    container_name: prometheus
+    image: prom/prometheus:v2.20.0
+    network_mode: host
+    command:
+      # Default commands from Dockerfile
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.console.libraries=/usr/share/prometheus/console_libraries"
+      - "--web.console.templates=/usr/share/prometheus/consoles"
+      # Our custom commands - metrics will be stored for 400 days
+      - "--storage.tsdb.retention.time=400d"
+      - "--web.listen-address=127.0.0.1:9090"
+    volumes:
+      - "./prometheus.yaml:/etc/prometheus/prometheus.yml"
+      - "prometheus_data:/prometheus"
+    restart: unless-stopped
+
+  grafana:
+    container_name: grafana
+    image: grafana/grafana:7.1.1
+    network_mode: host
+    environment:
+      GF_SERVER_HTTP_ADDR: "127.0.0.1"
+      GF_SERVER_HTTP_PORT: "{{ bbb_monitoring_port }}"
+      GF_SERVER_ROOT_URL: "https://{{ bbb_hostname }}/monitoring"
+    volumes:
+      - "grafana_data:/var/lib/grafana"
+    restart: unless-stopped
+
+  node_exporter:
+    container_name: node_exporter
+    image: prom/node-exporter:v1.0.1
+    network_mode: host
+    command:
+      - "--path.rootfs=/host"
+      - "--web.listen-address=127.0.0.1:9100"
+    pid: "host"
+    volumes:
+      - type: "bind"
+        source: "/"
+        target: "/host"
+        read_only: true
+    restart: unless-stopped
+
+volumes:
+  prometheus_data:
+  grafana_data:

--- a/templates/monitoring/docker-compose.yaml.j2
+++ b/templates/monitoring/docker-compose.yaml.j2
@@ -2,7 +2,7 @@ version: '3.2'
 services:
   bbb-exporter:
     container_name: bbb-exporter
-    image: greenstatic/bigbluebutton-exporter:v0.5.2
+    image: greenstatic/bigbluebutton-exporter:{{ bbb_monitoring_all_in_one_version }}
     network_mode: host
     volumes:
       # Can be removed if `RECORDINGS_METRICS_READ_FROM_DISK` is set to false (or omitted).

--- a/templates/monitoring/monitoring.nginx.j2
+++ b/templates/monitoring/monitoring.nginx.j2
@@ -1,0 +1,4 @@
+location /monitoring/ {
+  proxy_pass http://127.0.0.1:{{ bbb_monitoring_port }}/;
+  include proxy_params;
+}

--- a/templates/monitoring/monitoring.nginx.j2
+++ b/templates/monitoring/monitoring.nginx.j2
@@ -1,4 +1,4 @@
 location /monitoring/ {
-  proxy_pass http://127.0.0.1:{{ bbb_monitoring_port }}/;
+  proxy_pass http://127.0.0.1:{{ bbb_monitoring_all_in_one_port }}/;
   include proxy_params;
 }

--- a/templates/monitoring/prometheus.yaml.j2
+++ b/templates/monitoring/prometheus.yaml.j2
@@ -1,0 +1,32 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+  scrape_timeout: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']
+
+  - job_name: 'bbb'
+    relabel_configs:
+      - source_labels: ['__address__']
+        separator:     ':'
+        regex:         '(.*):.*'
+        target_label:  'instance'
+        replacement:   '$1'
+    static_configs:
+      - targets: ['localhost:9688']
+
+  - job_name: 'bbb_node_exporter'
+    params:
+      format: [prometheus]
+    honor_labels: true
+    relabel_configs:
+      - source_labels: ['__address__']
+        separator:     ':'
+        regex:         '(.*):.*'
+        target_label:  'instance'
+        replacement:   '$1'
+    static_configs:
+      - targets: ['localhost:9100']


### PR DESCRIPTION
Using `bbb_monitoring_enable` the bbb monitoring web app[^1] can be
installed on the host. It utilises the all-in-one Monitoring stack[^2] which
comes as a docker compose.

[^1]: https://github.com/greenstatic/bigbluebutton-monitoring
[^2]: https://bigbluebutton-exporter.greenstatic.dev/installation/all_in_one_monitoring_stack/