### PR TITLE
Fix docker-compose dependency

### DIFF
--- a/tasks/greenlight.yml
+++ b/tasks/greenlight.yml
@@ -10,7 +10,7 @@
   pip:
     name:
       - docker
-      - docker-compose
+      - docker-compose==1.24.1
     state: "{{ bbb_state }}"
 
 - name: create greenlight directory


### PR DESCRIPTION
This is just a quick fix to make it apply again. 

The underlying issue is that (since ~a week) applying the role fails for me because of an old pip version on Ubuntu 16. Details: https://github.com/python/importlib_metadata/issues/259

To fix the issue you can upgrade pip manually (pip3 install --upgrade pip) - but afterwards this task fails with an installation error. I tried which is the newest version of docker-compose which can be installed… and with 1.24.1 it worked again.

A complete fix would also upgrade the pip version somewhere.