### PR TITLE
add options to configure greenlight users

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Ansible role for a bigbluebutton installation (following the documentation on ht
 | `bbb_greenlight_secret` | Secret for greenlight _(required when using greenlight)_ |  | can be generated with `openssl rand -hex 64`
 | `bbb_greenlight_db_password` | Password for greenlight's database  _(required when using greenlight)_ | | can be generated with `openssl rand -hex 16`
 | `bbb_greenlight_default_registration` | Registration option open(default), invite or approval
+| `bbb_greenlight_users` | Greenlight users' list to create. No email notification will be triggered. As it contains passwords, recommend to put in ansible-vault | `[]` |
 | `bbb_allow_mail_notifications`  | Set this to true if you want GreenLight to send verification emails upon the creation of a new account | `true` |
 | `bbb_disable_recordings` | Disable options in gui to have recordings | `no` | [Recordings are running constantly in background](https://github.com/bigbluebutton/bigbluebutton/issues/9202) which is relevant as privacy relevant user data is stored
 | `bbb_api_demos_enable` | enable installation of the api demos | `no` |

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Ansible role for a bigbluebutton installation (following the documentation on ht
 | `bbb_greenlight_secret` | Secret for greenlight _(required when using greenlight)_ |  | can be generated with `openssl rand -hex 64`
 | `bbb_greenlight_db_password` | Password for greenlight's database  _(required when using greenlight)_ | | can be generated with `openssl rand -hex 16`
 | `bbb_greenlight_default_registration` | Registration option open(default), invite or approval
-| `bbb_greenlight_users` | Greenlight users' list to create. No email notification will be triggered. As it contains passwords, recommend to put in ansible-vault | `[]` |
+| `bbb_greenlight_users` | Greenlight users' list to create. No email notification will be triggered. As it contains passwords, recommend to put in ansible-vault. for more details see defaults/main.yml | `[]` |
 | `bbb_allow_mail_notifications`  | Set this to true if you want GreenLight to send verification emails upon the creation of a new account | `true` |
 | `bbb_disable_recordings` | Disable options in gui to have recordings | `no` | [Recordings are running constantly in background](https://github.com/bigbluebutton/bigbluebutton/issues/9202) which is relevant as privacy relevant user data is stored
 | `bbb_api_demos_enable` | enable installation of the api demos | `no` |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -26,6 +26,10 @@ bbb_turn_servers:
   tls: true
 
 bbb_greenlight_enable: true
+bbb_greenlight_users: []
+#  - { name: '', email: '', password: '', type: 'user' }
+#  - { name: '', email: '', password: '', type: 'admin' }
+
 bbb_webhooks_enable: false
 bbb_allow_mail_notifications: true
 bbb_greenlight_hosts: "{{ bbb_hostname }}"

--- a/tasks/greenlight.yml
+++ b/tasks/greenlight.yml
@@ -44,7 +44,7 @@
     # https://docs.bigbluebutton.org/greenlight/gl-admin.html#creating-accounts
     - name: Create greenlight users
       command: "docker exec greenlight-v2 bundle exec rake user:create[\"{{ item.name }}\",\"{{ item.email }}\",\"{{ item.password }}\",\"{{ item.type }}\"]"
-      with_items: "{{ bbb_greenlight_users }}"
+      loop: "{{ bbb_greenlight_users | flatten(levels=1) }}"
       register: usercreate
       failed_when: "'Invalid Arguments' in usercreate.stdout"
       changed_when: "'Account with that email already exists' not in usercreate.stdout"

--- a/tasks/greenlight.yml
+++ b/tasks/greenlight.yml
@@ -35,8 +35,18 @@
   - greenlight-redirect.nginx
   notify: reload nginx
 
-- name: start greenlight
-  docker_compose:
-    pull: true
-    project_src: /root/greenlight/
+- block:
+    - name: start greenlight
+      docker_compose:
+        pull: true
+        project_src: /root/greenlight/
+
+    # https://docs.bigbluebutton.org/greenlight/gl-admin.html#creating-accounts
+    - name: Create greenlight users
+      command: "docker exec greenlight-v2 bundle exec rake user:create[\"{{ item.name }}\",\"{{ item.email }}\",\"{{ item.password }}\",\"{{ item.type }}\"]"
+      with_items: "{{ bbb_greenlight_users }}"
+      register: usercreate
+      failed_when: "'Invalid Arguments' in usercreate.stdout"
+      changed_when: "'Account with that email already exists' not in usercreate.stdout"
+
   when: bbb_greenlight_enable | bool

--- a/test/integration/default/default.yml
+++ b/test/integration/default/default.yml
@@ -14,6 +14,9 @@
     bbb_greenlight_db_password: 2585c27c785e8895ec
     bbb_letsencrypt_enable: false
     bbb_letsencrypt_email: mail@example.com
+    bbb_greenlight_enable: true
+    bbb_greenlight_users:
+      - { name: 'user1', email: 'user1@example.com', password: 'user1@example.com', type: 'user' }
   pre_tasks:
     - name: Bionic+ | Set mongodb to 4.2
       set_fact:


### PR DESCRIPTION
This PR allows to pre-configure in ansible role some registered greenlight users
variable with password should be stored in vault for better security