### PR TITLE
Fix readme example for use of ternary()

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ bbb_greenlight_office365:
 By default, the ability for anyone to create a Greenlight account is enabled. To disable this, use `false`.
 For more information see: https://docs.bigbluebutton.org/greenlight/gl-config.html#in-application-greenlight
 ```yaml
-bbb_greenlight_accounts: 'false'
+bbb_greenlight_accounts: false
 ```
 
 #### RECAPTCHA


### PR DESCRIPTION
`'false' | ternary('true', 'false')` ends up being 'true'.
Adapt the example to the use of ternary