### PR TITLE
Pin requirements roles to specific versions

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,7 +1,9 @@
 ---
 roles:
   - src: geerlingguy.nodejs
+    version: 6.0.0
   - src: geerlingguy.docker
+    version: 4.1.0
 
 collections:
   - name: community.general


### PR DESCRIPTION
When updating requirements (for example when bumping the `ansible-role-bigbluebutton` version in a playbook), recursive version are also checked / updated if needed. Currently, doing `ansible-galaxy install -r requirements.yml` will result in a message similar to:
```
[WARNING]: - dependency geerlingguy.nodejs (None) from role bigbluebutton differs from already installed version (5.1.1), skipping
[WARNING]: - dependency geerlingguy.docker (None) from role bigbluebutton differs from already installed version (3.1.2), skipping
```
if you already have the dependencies present. This happens because the versions of the dependencies used are not pinned, hence they cannot be compared with the already installed version.

Pinning requirement to specific versions allow installing the correct version. While currently I'm sure most version of  the `nodejs` and `docker` roles would work, in the future if we required a specific one, it will be easier to deal with.

I opted to use the most recent versions of both roles as a starting point.