### PR TITLE
bbb_secret cast to string

### DIFF
--- a/tasks/check-for-sessions.yml
+++ b/tasks/check-for-sessions.yml
@@ -1,7 +1,7 @@
 ---
 - name: Check for running meetings
   uri:
-    url: "https://{{ bbb_hostname }}/bigbluebutton/api/getMeetings?checksum={{ ('getMeetings' + bbb_secret) | hash('sha1') }}"
+    url: "https://{{ bbb_hostname }}/bigbluebutton/api/getMeetings?checksum={{ ('getMeetings' + (bbb_secret | string)) | hash('sha1') }}"
     return_content: true
   register: bbb_getmeetings
   failed_when: false


### PR DESCRIPTION
bbb_secret might be ansible-vault encrypted.

in this case you will face the following error: 

`Unexpected templating type error occurred on (https://{{ bbb_hostname }}/bigbluebutton/api/getMeetings?checksum={{ ('getMeetings' + bbb_secret) | hash('sha1') }}): can only concatenate str (not "AnsibleVaultEncryptedUnicode") to str`

my change will make it work in all cases