### PR TITLE
ssl-cert package for cert permissions

### DIFF
--- a/tasks/certificate.yml
+++ b/tasks/certificate.yml
@@ -7,6 +7,14 @@
     state: directory
     mode: '0755'
 
+- name: Install ssl-cert package
+  become: true
+  apt:
+    pkg:
+      - ssl-cert
+    update_cache: true
+    state: "{{ bbb_state }}"
+
 - import_tasks: certificate-letsencrypt.yml
   when: bbb_letsencrypt_enable|bool
 


### PR DESCRIPTION
[this](https://github.com/ebbba-org/ansible-role-bigbluebutton/commit/cb512201026171b5f7cefee3bb39f6153c53eb5a) commit sets the group permissions for the bbb_own_key or bbb_ssl_key to "ssl-cert". So it has to be ensured that this group is existing, otherwise the task will fail (like on my Ubuntu 18.04).