### PR TITLE
bbb_greenlight_image_pull setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Also check [Before you install](https://docs.bigbluebutton.org/2.3/install.html#
 | | `bbb_greenlight_enable` | enable installation of the greenlight client | `yes` | |
 | | `bbb_greenlight_hosts` | the hostname that greenlight is accessible from | `{{ bbb_hostname }}` | |
 | | `bbb_greenlight_image` | the Docker image to be used for greenlight, so you can use a custom version | `bigbluebutton/greenlight:v2` | |
+| | `bbb_greenlight_image_pull` | control the image pull for the greenlight image | `true` | if you are using a custom `bbb_greenlight_image` value, you might want to disable the pull and use a local image |
 | ⚠️ when using greenlight | `bbb_greenlight_secret` | Secret for greenlight |  | can be generated with `openssl rand -hex 64` |
 | ⚠️ when using greenlight | `bbb_greenlight_db_password` | Password for greenlight's database | | can be generated with `openssl rand -hex 16` |
 | | `bbb_greenlight_default_registration` | Registration option open(default), invite or approval | `open` | |

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,6 +43,7 @@ bbb_webhooks_enable: false
 bbb_allow_mail_notifications: true
 bbb_greenlight_hosts: "{{ bbb_hostname }}"
 bbb_greenlight_image: bigbluebutton/greenlight:v2
+bbb_greenlight_image_pull: true
 bbb_greenlight_enable_recording_thumbnails: true
 bbb_api_demos_enable: false
 bbb_app_log_level: "DEBUG"

--- a/tasks/greenlight.yml
+++ b/tasks/greenlight.yml
@@ -34,7 +34,7 @@
 - block:
     - name: start greenlight
       docker_compose:
-        pull: true
+        pull: "{{ bbb_greenlight_image_pull }}"
         project_src: /root/greenlight/
 
     # https://docs.bigbluebutton.org/greenlight/gl-admin.html#creating-accounts


### PR DESCRIPTION
added a new setting to control the behaviour of docker-compose to pull the greenlight image. this allows to use local images, which are not available in any docker registry. the default settings is the previous value, "true".