### PR TITLE
fix: check-vars for NFS

### DIFF
--- a/tasks/check-vars.yml
+++ b/tasks/check-vars.yml
@@ -121,7 +121,7 @@
     quiet: true
     that: "{{ item }}"
   loop:
-    - bbb_nfs_mount is undefined
+    - bbb_nfs_share is undefined
     - bbb_symlink_var is abs
     - not bbb_symlink_var.startswith('/var/bigbluebutton')
     - bbb_symlink_log is abs


### PR DESCRIPTION
bbb_nfs_mount is always defined (it has a default) but ignored if bbb_nfs_share is undefined.