### PR TITLE
bugfix/dialin_provider_ip_check

### DIFF
--- a/tasks/check-vars.yml
+++ b/tasks/check-vars.yml
@@ -142,7 +142,16 @@
     that: "{{ item }}"
   loop:
     - bbb_dialin_provider is ip or bbb_dialin_provider is fqdn
-    - bbb_dialin_provider_ip is ip or bbb_dialin_provider_ip is netmask
     - bbb_dialin_provider_username is present
     - bbb_dialin_provider_password is present
     - bbb_dialin_provider_extension is present
+
+- name: Check dial-in firewall relevant variables
+  when:
+     - bbb_dialin_enable
+     - bbb_firewall_enable
+  ansible.builtin.assert:
+    quiet: true
+    that: "{{ item }}"
+  loop:
+    - bbb_dialin_provider_ip is ip or bbb_dialin_provider_ip is netmask


### PR DESCRIPTION
The [documentation](https://github.com/ebbba-org/ansible-role-bigbluebutton/blob/master/README.md) said that the variable `bbb_dialin_provider_ip` is only required if  if `bbb_dialin_enable` **and** `bbb_firewall_enable` are true.
Independent that `bbb_firewall_enable` is not defined in any other parts of the role and the default of `bbb_ufw_enable` is false, is this bugfix relevant