### PR TITLE
bugfix/remove-hostname-check

### DIFF
--- a/tasks/check-vars.yml
+++ b/tasks/check-vars.yml
@@ -30,7 +30,6 @@
     that: "{{ item }}"
   loop:
     - bbb_secret is defined
-    - bbb_hostname is fqdn
     - bbb_apt_mirror is url
     - bbb_apt_key is url
     - bbb_disabled_features is subset(bbb_allowed_disabled_features)


### PR DESCRIPTION
The README documentation says that `bbb_hostname` has `ansible_fqdn` as default. Why are there any checks? Maybe someone will run a BBB server with an other FQDN than BBB hostname.