### PR TITLE
fix: Proxy setup CORS headers

### DIFF
--- a/templates/bbb-config/nginx/sites-available/bigbluebutton.j2
+++ b/templates/bbb-config/nginx/sites-available/bigbluebutton.j2
@@ -45,6 +45,9 @@ server {
   set $real_scheme "https";
 
 {% if bbb_cluster_proxy is defined %}
+  # Used by BBB includes for CORS headers
+  set $bbb_cors_origin 'https://{{ bbb_cluster_proxy }}';
+
   rewrite ^/{{bbb_cluster_node}}/(.*)$ /$1 last;
 
   location = /html5client/locale {


### PR DESCRIPTION
BBB 3.0.28 introduced a new nginx config variable named `$bbb_cors_origin` which is used throughout BBB nginx includes as the value for `Access-Control-Allow-Origin` headers and defaults to `*`. Wildcard origins do not allow CORS requests with credentials (e.g. cookies), so this has to be defined for clusters with a proxy.