### PR TITLE
ImageMagick policy override for thumbnail generation

### DIFF
--- a/files/ImageMagick-policy.xml
+++ b/files/ImageMagick-policy.xml
@@ -84,6 +84,8 @@
   <!-- don't read sensitive paths. -->
   <policy domain="path" rights="none" pattern="/*"/>
   <!-- allow access to required paths. -->
+  <policy domain="path" rights="read" pattern="/usr/share/bigbluebutton/html5-client/resources/images/virtual-backgrounds/*"/>
+  <policy domain="path" rights="write" pattern="/usr/share/bigbluebutton/html5-client/resources/images/virtual-backgrounds/thumbnails/*"/>
   <policy domain="path" rights="read|write" pattern="/var/bigbluebutton/*"/>
   <policy domain="path" rights="read|write" pattern="/tmp/*"/>
   <!-- Indirect reads are not permitted. -->


### PR DESCRIPTION
[ImageMagick policy override for thumbnail generation](https://github.com/ebbba-org/ansible-role-bigbluebutton/commit/16a84b57c86c91f1481cd3cf7d1174b96917004c)

BBB ships a restrictive policy file for ImageMagick that prevents the re-generation of thumbnails. This adds an override that gets applied only when ImageMagick binaries are executed in the `virtual-backgrounds`-base path.

This file and path could possibly be removed after our work is done, but otoh if anyone can write files somewhere, they still could write their own override file.